### PR TITLE
Ensure harmony package is importable when running app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,15 @@
+from pathlib import Path
+import sys
+
+# Ensure the project root (which contains the ``harmony`` package) is on the
+# import path when the module is executed directly. This mirrors the behaviour
+# of ``python -m`` and prevents ``ModuleNotFoundError`` when running the script
+# from environments where the working directory is different from the file's
+# location (e.g. PowerShell on Windows).
+BASE_DIR = Path(__file__).resolve().parent
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
 from harmony import create_app, socketio
 
 app = create_app()


### PR DESCRIPTION
## Summary
- add an explicit sys.path adjustment in app.py so the harmony package can always be imported when the script is executed directly

## Testing
- python - <<'PY'
import runpy
try:
    runpy.run_path('app.py', run_name='__main__')
except ModuleNotFoundError as exc:
    print('ModuleNotFoundError:', exc)
PY

------
https://chatgpt.com/codex/tasks/task_e_68dabbcad0748327bd0c959cb1998b27