### PR TITLE
Guard message sending by session user

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from harmony import create_app
+from harmony.extensions import csrf, db, talisman
+
+
+@pytest.fixture(scope="session")
+def app(tmp_path_factory):
+    test_db_path = tmp_path_factory.mktemp("data") / "test.db"
+    app = create_app()
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI=f"sqlite:///{test_db_path}",
+        WTF_CSRF_ENABLED=False,
+        SERVER_NAME="localhost",
+        SESSION_COOKIE_SECURE=False,
+        TALISMAN_FORCE_HTTPS=False,
+    )
+
+    csrf.exempt(app.view_functions["main.send_message"])
+    talisman.force_https = False
+    talisman.force_https_permanent = False
+
+    with app.app_context():
+        db.session.remove()
+        db.engine.dispose()
+        db.drop_all()
+        db.create_all()
+
+    yield app
+
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.engine.dispose()
+
+
+@pytest.fixture
+def client(app):
+    test_client = app.test_client()
+    test_client.environ_base["wsgi.url_scheme"] = "https"
+    return test_client
+
+

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -1,0 +1,79 @@
+from harmony.extensions import socketio
+
+
+def test_send_message_requires_login(client):
+    response = client.post(
+        "/messages",
+        json={"sender_id": 1, "receiver_id": 2, "content": "Hello"},
+    )
+    assert response.status_code == 401
+    assert response.is_json
+    assert response.get_json() == {"error": "User not logged in"}
+
+
+def test_send_message_forbidden_with_mismatched_sender(client):
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+
+    response = client.post(
+        "/messages",
+        json={"sender_id": 2, "receiver_id": 3, "content": "Hello"},
+    )
+    assert response.status_code == 403
+    assert response.is_json
+    assert response.get_json() == {"error": "Forbidden"}
+
+
+def test_send_message_form_flow_forbidden_with_mismatched_sender(client):
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+
+    response = client.post(
+        "/messages",
+        data={"sender_id": "2", "receiver_id": "3", "message": "Hi"},
+    )
+    assert response.status_code == 403
+
+
+def test_socket_send_message_requires_login(app, client):
+    socket_client = socketio.test_client(app, flask_test_client=client)
+    assert socket_client.is_connected(), "Socket.IO test client failed to connect"
+    # Clear any connection events before emitting test data.
+    socket_client.get_received(namespace="/")
+    socket_client.emit(
+        "send_message",
+        {"sender_id": 1, "receiver_id": 2, "content": "Hi"},
+        namespace="/",
+    )
+    received = socket_client.get_received(namespace="/")
+    if not received:
+        received = socket_client.get_received(namespace="/")
+    assert received, "No events were received from the Socket.IO server"
+    assert any(
+        event["name"] == "error" and event["args"][0]["error"] == "User not logged in"
+        for event in received
+    )
+    socket_client.disconnect()
+
+
+def test_socket_send_message_forbidden_with_mismatched_sender(app, client):
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+
+    socket_client = socketio.test_client(app, flask_test_client=client)
+    assert socket_client.is_connected(), "Socket.IO test client failed to connect"
+    socket_client.get_received(namespace="/")
+    socket_client.emit(
+        "send_message",
+        {"sender_id": 2, "receiver_id": 3, "content": "Hi"},
+        namespace="/",
+    )
+    received = socket_client.get_received(namespace="/")
+    if not received:
+        received = socket_client.get_received(namespace="/")
+    assert received, "No events were received from the Socket.IO server"
+    assert any(
+        event["name"] == "error" and event["args"][0]["error"] == "Forbidden"
+        for event in received
+    )
+    socket_client.disconnect()


### PR DESCRIPTION
## Summary
- enforce session-based authorization for the `/messages` endpoint and use the session sender when persisting messages
- require authenticated senders for the Socket.IO `send_message` handler and emit consistent authorization errors
- add pytest coverage that exercises unauthorized REST and Socket.IO messaging attempts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dacc441cd483278664685a839c6f6f