### PR TITLE
Protect message retrieval with session checks

### DIFF
--- a/harmony/routes/main.py
+++ b/harmony/routes/main.py
@@ -331,7 +331,17 @@ def get_profiles_api():
 
 @bp.route("/api/messages/<int:receiver_id>")
 def get_messages_api(receiver_id):
-    user_id = session.get("user_id")
+    session_user_id = session.get("user_id")
+    if not session_user_id:
+        return jsonify({"error": "User not logged in"}), 401
+
+    if receiver_id == session_user_id:
+        return jsonify({"error": "Forbidden"}), 403
+
+    if not check_match(session_user_id, receiver_id):
+        return jsonify({"error": "Forbidden"}), 403
+
+    user_id = session_user_id
     messages = (
         Message.query.filter(
             ((Message.sender_id == user_id) & (Message.receiver_id == receiver_id))


### PR DESCRIPTION
## Summary
- ensure the message API requires a logged-in user
- block message retrieval when the requester is not part of a mutual match
- add tests covering authorized and unauthorized message API calls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dad15023708327bf047c27d482da09