### PR TITLE
Refresh Spotify login experience

### DIFF
--- a/harmony/routes/auth.py
+++ b/harmony/routes/auth.py
@@ -1,7 +1,16 @@
 import secrets
 
 import requests
-from flask import Blueprint, current_app, jsonify, redirect, request, session, url_for
+from flask import (
+    Blueprint,
+    current_app,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 
 from ..extensions import db, limiter
 from ..models import User
@@ -28,7 +37,7 @@ def login():
         f"&scope={scope}"
         f"&state={state}"
     )
-    return redirect(auth_url)
+    return render_template("login.html", auth_url=auth_url)
 
 
 @bp.route("/callback")

--- a/static/css/auth.css
+++ b/static/css/auth.css
@@ -1,0 +1,196 @@
+:root {
+  --spotify-green: #1db954;
+  --spotify-green-dark: #169044;
+  --surface-dark: rgba(18, 18, 18, 0.75);
+  --surface-light: rgba(255, 255, 255, 0.08);
+  --text-primary: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.78);
+  --border-subtle: rgba(255, 255, 255, 0.12);
+  --shadow-elevated: 0 25px 45px rgba(10, 10, 10, 0.6);
+  --shadow-floating: 0 25px 50px rgba(0, 0, 0, 0.55);
+  --blur-strength: blur(18px);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.auth-body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Poppins', 'Helvetica Neue', Arial, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: radial-gradient(circle at top left, rgba(29, 185, 84, 0.65), transparent 60%),
+    radial-gradient(circle at bottom right, rgba(94, 59, 238, 0.55), transparent 55%),
+    linear-gradient(135deg, #0b0f15 0%, #0f1015 45%, #050507 100%);
+  color: var(--text-primary);
+  overflow: hidden;
+}
+
+body.auth-body::before,
+body.auth-body::after {
+  content: '';
+  position: absolute;
+  width: 380px;
+  height: 380px;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.45;
+  z-index: 0;
+}
+
+body.auth-body::before {
+  background: #1db954;
+  top: -140px;
+  left: -140px;
+}
+
+body.auth-body::after {
+  background: #6c63ff;
+  bottom: -160px;
+  right: -120px;
+}
+
+.auth-wrapper {
+  position: relative;
+  z-index: 1;
+  width: min(300px, 92vw);
+  background: var(--surface-dark);
+  backdrop-filter: var(--blur-strength);
+  border-radius: 22px;
+  padding: 34px 30px;
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-floating);
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.brand-badge {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.brand-badge .logo-ring {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: linear-gradient(145deg, rgba(29, 185, 84, 0.85), rgba(13, 68, 31, 0.85));
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 2px 8px rgba(255, 255, 255, 0.08), 0 12px 18px rgba(29, 185, 84, 0.25);
+}
+
+.brand-badge .logo-ring svg {
+  width: 22px;
+  height: 22px;
+  fill: #ffffff;
+}
+
+.brand-badge h1 {
+  font-size: clamp(1.4rem, 2.1vw, 1.9rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+.copy-block {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.copy-block h2 {
+  margin: 0;
+  font-size: clamp(1.1rem, 2vw, 1.4rem);
+  font-weight: 600;
+}
+
+.copy-block p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  font-size: 0.85rem;
+}
+
+.feature-list {
+  display: grid;
+  gap: 10px;
+}
+
+.feature-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--surface-light);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.feature-item .icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  background: rgba(29, 185, 84, 0.16);
+  color: var(--spotify-green);
+  font-size: 1rem;
+}
+
+.feature-item span {
+  font-size: 0.8rem;
+  letter-spacing: 0.01em;
+}
+
+.login-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 12px 18px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: linear-gradient(135deg, var(--spotify-green), var(--spotify-green-dark));
+  border-radius: 999px;
+  text-decoration: none;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  box-shadow: 0 18px 35px rgba(29, 185, 84, 0.32);
+  align-self: center;
+}
+
+.login-button:hover {
+  transform: translateY(-4px) scale(1.01);
+  box-shadow: 0 24px 45px rgba(29, 185, 84, 0.42);
+}
+
+.login-button svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.legal-text {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.55);
+  text-align: center;
+  line-height: 1.5;
+}
+
+@media (max-width: 540px) {
+  .auth-wrapper {
+    width: min(280px, 92vw);
+    padding: 26px 22px;
+    gap: 18px;
+  }
+
+  .feature-item {
+    padding: 8px 10px;
+  }
+}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,13 +1,53 @@
-<!-- templates/login.html -->
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title>Login with Spotify</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sign in • Harmony</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
 </head>
-<body>
-    <h1>Login with Spotify</h1>
-    <p>Click the link below to start Spotify OAuth</p>
-    <a href="{{ auth_url }}">Login</a>
+<body class="auth-body">
+    <main class="auth-wrapper" role="main">
+        <div class="brand-badge" aria-label="Harmony brand">
+            <div class="logo-ring" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+                    <path d="M21.57 0H2.43A2.43 2.43 0 0 0 0 2.43v19.14A2.43 2.43 0 0 0 2.43 24h19.14A2.43 2.43 0 0 0 24 21.57V2.43A2.43 2.43 0 0 0 21.57 0Zm-2.09 17.46a1 1 0 0 1-1.38.34c-3.79-2.32-8.56-2.85-14.18-1.6a1 1 0 0 1-.44-1.95c6.09-1.38 11.3-.77 15.53 1.81a1 1 0 0 1 .47 1.4Zm1.84-4.13a1.23 1.23 0 0 1-1.7.41c-4.33-2.66-10.93-3.44-16-1.93a1.23 1.23 0 0 1-.68-2.37c5.73-1.64 12.92-.76 17.85 2.18a1.23 1.23 0 0 1 .43 1.71Zm.16-4.32C16.48 5.92 8.5 5.63 3.78 7a1.46 1.46 0 0 1-.84-2.8c5.38-1.63 13.92-1.28 19.32 2.08a1.46 1.46 0 1 1-1.5 2.53Z" />
+                </svg>
+            </div>
+            <h1>Harmony</h1>
+        </div>
+
+        <section class="copy-block">
+            <h2>Log in with Spotify to begin</h2>
+            <p>Connect your Spotify account to generate personalised matches, share playlists and discover new music companions curated around your listening habits.</p>
+        </section>
+
+        <section class="feature-list" aria-label="What you get">
+            <div class="feature-item">
+                <span class="icon" aria-hidden="true">🎧</span>
+                <span>See your top artists, tracks and genres in a gorgeous dashboard.</span>
+            </div>
+            <div class="feature-item">
+                <span class="icon" aria-hidden="true">🤝</span>
+                <span>Find music matches with similar tastes and start conversations instantly.</span>
+            </div>
+            <div class="feature-item">
+                <span class="icon" aria-hidden="true">🔒</span>
+                <span>Your credentials stay safe — authentication happens securely through Spotify.</span>
+            </div>
+        </section>
+
+        <a class="login-button" href="{{ auth_url }}">
+            <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+                <path d="M12 0a12 12 0 1 0 12 12A12.013 12.013 0 0 0 12 0Zm5.31 17.35a.75.75 0 0 1-1.03.26c-3.01-1.83-6.78-2.24-11.22-1.26a.75.75 0 1 1-.31-1.47c4.84-1.03 8.99-.57 12.4 1.4a.75.75 0 0 1 .26 1.07Zm1.37-3.44a.94.94 0 0 1-1.29.3c-3.44-2.1-8.68-2.72-12.71-1.53a.94.94 0 1 1-.54-1.8c4.52-1.3 10.21-.6 14.1 1.72a.94.94 0 0 1 .44 1.3Zm.13-3.6c-4.12-2.47-11.06-2.7-15.11-1.52a1.13 1.13 0 1 1-.66-2.16c4.67-1.43 12.47-1.15 17.15 1.66a1.13 1.13 0 0 1-1.17 2.02Z" />
+            </svg>
+            Continue with Spotify
+        </a>
+
+        <p class="legal-text">By continuing you agree to let Harmony access your Spotify listening data so we can craft better matches. We never post on your behalf.</p>
+    </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the Spotify login template with a polished hero layout, feature highlights, and accessible structure
- add a dedicated auth stylesheet that delivers the new gradient backdrop, glassmorphism card, and button styling
- scale the login card down by roughly 30% and tighten spacing so the experience fits comfortably at the center of the screen

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dad691d5608327ae32283134821353