### PR TITLE
Enhance find profiles page styling

### DIFF
--- a/templates/match.html
+++ b/templates/match.html
@@ -4,199 +4,404 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Harmony - Find Profiles</title>
-  <!-- Font Awesome & Google Fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet" />
-  <!-- Interact.js CDN -->
   <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
   <style>
-    /* Genel Stil */
-    body {
-      font-family: 'Roboto', sans-serif;
-      background: linear-gradient(135deg, #121212, #1db954);
-      color: #fff;
+    :root {
+      --primary: #1db954;
+      --primary-dark: #169943;
+      --background: #0b1117;
+      --card: rgba(18, 18, 18, 0.92);
+      --card-border: rgba(255, 255, 255, 0.08);
+      --text: #f5f5f5;
+      --muted: rgba(245, 245, 245, 0.75);
+      --accent: #4dd0e1;
+      --gradient: linear-gradient(135deg, rgba(29, 185, 84, 0.95), rgba(18, 18, 18, 0.95));
+    }
+
+    * {
+      box-sizing: border-box;
       margin: 0;
       padding: 0;
+    }
+
+    body {
+      font-family: 'Poppins', sans-serif;
+      background: var(--background);
+      color: var(--text);
+      min-height: 100vh;
       display: flex;
       flex-direction: column;
-      min-height: 100vh;
+      position: relative;
       overflow-x: hidden;
     }
+
+    body::before,
+    body::after {
+      content: "";
+      position: fixed;
+      width: 420px;
+      height: 420px;
+      border-radius: 50%;
+      filter: blur(140px);
+      z-index: -2;
+      opacity: 0.55;
+    }
+
+    body::before {
+      background: rgba(29, 185, 84, 0.5);
+      top: -160px;
+      left: -120px;
+    }
+
+    body::after {
+      background: rgba(77, 208, 225, 0.35);
+      bottom: -180px;
+      right: -140px;
+    }
+
     header {
-      background: #121212;
-      padding: 15px 20px;
+      width: 100%;
+      padding: 24px 7vw;
       display: flex;
       justify-content: space-between;
       align-items: center;
-      border-bottom: 2px solid #1db954;
-      width: 100%;
-      position: fixed;
+      position: sticky;
       top: 0;
-      left: 0;
-      z-index: 1000;
+      z-index: 10;
+      background: linear-gradient(180deg, rgba(11, 17, 23, 0.92) 0%, rgba(11, 17, 23, 0) 100%);
+      backdrop-filter: blur(18px);
     }
-    header h1 {
-      margin: 0;
-      font-size: 2.5rem;
-      color: #1db954;
-      text-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+
+    .logo {
+      font-size: 1.8rem;
+      font-weight: 700;
+      letter-spacing: 1.5px;
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
     }
+
+    .logo span {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 42px;
+      height: 42px;
+      border-radius: 50%;
+      background: var(--gradient);
+      box-shadow: 0 10px 30px rgba(29, 185, 84, 0.35);
+      font-size: 1.2rem;
+    }
+
     .header-right {
       display: flex;
       align-items: center;
-      gap: 10px;
-      transform: translateX(-50px);
+      gap: 18px;
     }
-    header img {
+
+    .profile-thumb {
       width: 50px;
       height: 50px;
       border-radius: 50%;
-      cursor: pointer;
-      box-shadow: 0 0 10px #1db954, 0 0 20px #1db954, 0 0 30px #1db954;
+      border: 2px solid rgba(255, 255, 255, 0.12);
+      object-fit: cover;
+      box-shadow: 0 0 0 4px rgba(29, 185, 84, 0.2);
       transition: transform 0.3s ease, box-shadow 0.3s ease;
-      transform: translateX(-20px);
-    }
-    header img:hover {
-      transform: scale(1.1) translateX(-20px);
-      box-shadow: 0 0 20px #1db954, 0 0 40px #1db954, 0 0 60px #1db954;
-    }
-    .neon-profile {
-      width: 50px;
-      height: 50px;
-      border-radius: 50%;
       cursor: pointer;
-      box-shadow: 0 0 10px #1db954, 0 0 20px #1db954, 0 0 30px #1db954;
-      transition: transform 0.3s ease, box-shadow 0.3s ease;
     }
-    .neon-profile:hover {
-      transform: scale(1.1);
-      box-shadow: 0 0 20px #1db954, 0 0 40px #1db954, 0 0 60px #1db954;
+
+    .profile-thumb:hover {
+      transform: scale(1.06);
+      box-shadow: 0 0 0 6px rgba(29, 185, 84, 0.35);
     }
-    .btn.neon-logout {
-      padding: 10px 20px;
-      background: #1db954;
-      color: #fff;
-      border-radius: 30px;
-      font-size: 1rem;
-      text-decoration: none;
-      font-weight: bold;
-      transition: background 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
-      box-shadow: 0 0 10px #1db954, 0 0 20px #1db954, 0 0 30px #1db954;
-    }
-    .btn.neon-logout:hover {
-      background: #1aa34a;
-      transform: scale(1.1);
-      box-shadow: 0 0 20px #1db954, 0 0 40px #1db954, 0 0 60px #1db954;
-    }
+
     .btn {
-      padding: 10px 20px;
-      background: #1db954;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 12px 22px;
+      background: var(--primary);
       color: #fff;
-      border-radius: 30px;
-      font-size: 1rem;
+      font-size: 0.95rem;
+      border-radius: 999px;
       text-decoration: none;
-      font-weight: bold;
-      transition: background 0.3s ease, transform 0.3s ease;
-      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
-    }
-    .btn:hover {
-      background: #1aa34a;
-      transform: scale(1.05);
-    }
-    .container {
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+      box-shadow: 0 12px 28px rgba(29, 185, 84, 0.25);
       position: relative;
-      width: 320px;
-      height: 520px;
-      margin: 100px auto 0;
-      background: #121212;
-    }
-    .card {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background-color: #1db954;
-      border-radius: 10px;
-      box-shadow: 0 4px 10px rgba(0,0,0,0.3);
-      color: #fff;
-      padding: 15px;
-      box-sizing: border-box;
       overflow: hidden;
+    }
+
+    .btn::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.25), transparent);
+      transform: translateX(-120%);
+      transition: transform 0.6s ease;
+    }
+
+    .btn:hover::after {
+      transform: translateX(120%);
+    }
+
+    .btn:hover {
+      transform: translateY(-2px) scale(1.02);
+      background: var(--primary-dark);
+    }
+
+    .btn.secondary {
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--text);
+      box-shadow: none;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .btn.secondary:hover {
+      background: rgba(255, 255, 255, 0.12);
+    }
+
+    main {
+      flex: 1;
+      padding: 40px 7vw 120px;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 48px;
+      align-items: start;
+    }
+
+    .match-intro {
       display: flex;
       flex-direction: column;
-      justify-content: space-between;
+      gap: 24px;
+    }
+
+    .match-intro h1 {
+      font-size: clamp(2rem, 3.5vw, 3rem);
+      line-height: 1.1;
+    }
+
+    .match-intro p {
+      color: var(--muted);
+      line-height: 1.7;
+      max-width: 480px;
+    }
+
+    .match-stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 16px;
+    }
+
+    .stat-card {
+      background: rgba(255, 255, 255, 0.05);
+      padding: 18px;
+      border-radius: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .stat-card span {
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+
+    .stat-card strong {
+      font-size: 1.3rem;
+    }
+
+    .match-controls {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .cards-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
+    }
+
+    .cards-wrapper h2 {
+      font-size: 1.4rem;
+      font-weight: 600;
+    }
+
+    .cards-wrapper p {
+      color: var(--muted);
+      font-size: 0.95rem;
+      text-align: center;
+      max-width: 320px;
+    }
+
+    .container {
+      position: relative;
+      width: clamp(280px, 32vw, 360px);
+      height: 520px;
+      perspective: 1200px;
+    }
+
+    .card {
+      position: absolute;
+      inset: 0;
+      background: var(--card);
+      border: 1px solid var(--card-border);
+      border-radius: 24px;
+      box-shadow: 0 25px 60px rgba(0, 0, 0, 0.45);
+      padding: 28px;
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
       touch-action: none;
     }
+
+    .card::before {
+      content: "";
+      position: absolute;
+      inset: -30% 40% auto -30%;
+      height: 140%;
+      background: radial-gradient(circle at top, rgba(77, 208, 225, 0.25), transparent 70%);
+      opacity: 0.6;
+      pointer-events: none;
+    }
+
     .card h2 {
-      margin: 5px 0;
-      font-size: 1.3em;
+      font-size: 1.45rem;
+      margin-bottom: 4px;
     }
+
     .card p {
-      font-size: 0.7em;
-      margin: 5px 0;
-      word-wrap: break-word;
+      font-size: 0.95rem;
+      color: var(--muted);
     }
-    .top-artists, .top-tracks {
-      margin: 5px 0;
+
+    .card-section {
+      background: rgba(255, 255, 255, 0.03);
+      border-radius: 18px;
+      padding: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.04);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
     }
-    .top-artists h3, .top-tracks h3 {
-      font-size: 1.1em;
-      margin-bottom: 5px;
+
+    .card-section h3 {
+      font-size: 1rem;
+      font-weight: 600;
     }
-    .artist, .song {
+
+    .artist,
+    .song {
       display: flex;
       align-items: center;
-      margin: 5px 0;
+      gap: 12px;
     }
-    .artist img, .song img {
-      width: 40px;
-      height: 40px;
-      border-radius: 5px;
-      margin-right: 10px;
+
+    .artist img,
+    .song img {
+      width: 46px;
+      height: 46px;
+      border-radius: 12px;
+      object-fit: cover;
+      box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
     }
+
+    .artist p,
+    .song p {
+      font-size: 0.95rem;
+      color: var(--text);
+    }
+
+    .tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .tag {
+      padding: 6px 14px;
+      border-radius: 999px;
+      background: rgba(29, 185, 84, 0.15);
+      color: var(--text);
+      font-size: 0.8rem;
+      border: 1px solid rgba(29, 185, 84, 0.25);
+    }
+
     .actions {
+      margin-top: auto;
       display: flex;
-      justify-content: space-around;
-      margin-top: 10px;
-    }
-    .actions button {
-      background-color: #191414;
-      border: none;
-      border-radius: 50%;
-      width: 50px;
-      height: 50px;
-      display: flex;
-      justify-content: center;
+      justify-content: space-between;
       align-items: center;
+      gap: 18px;
+    }
+
+    .actions button {
+      width: 66px;
+      height: 66px;
+      border-radius: 50%;
+      border: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.5rem;
       cursor: pointer;
-      transition: background-color 0.3s ease, transform 0.3s ease;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      color: #fff;
     }
-    .actions button i {
-      font-size: 1.5em;
-    }
+
     .actions button.pass {
-      background-color: #e74c3c;
+      background: rgba(231, 76, 60, 0.9);
+      box-shadow: 0 12px 30px rgba(231, 76, 60, 0.35);
     }
+
     .actions button.like {
-      background-color: #1db954;
+      background: rgba(29, 185, 84, 0.92);
+      box-shadow: 0 12px 30px rgba(29, 185, 84, 0.35);
     }
+
     .actions button:hover {
-      transform: scale(1.1);
+      transform: translateY(-4px) scale(1.05);
     }
+
+    .no-profiles {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 14px;
+      text-align: center;
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 24px;
+      padding: 40px 32px;
+      border: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .no-profiles h2 {
+      font-size: 1.6rem;
+      color: var(--primary);
+    }
+
+    .no-profiles p {
+      color: var(--muted);
+    }
+
     footer {
       text-align: center;
-      padding: 10px 0;
+      padding: 20px 0;
       font-size: 0.9rem;
-      background: #121212;
-      border-top: 2px solid #1db954;
-      width: 100%;
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      z-index: 1000;
+      background: linear-gradient(0deg, rgba(11, 17, 23, 0.95), rgba(11, 17, 23, 0.65));
+      border-top: 1px solid rgba(255, 255, 255, 0.04);
     }
-    /* Animasyonlar */
+
     @keyframes growHeart {
       0% {
         transform: translate(-50%, -50%) scale(0);
@@ -211,6 +416,7 @@
         opacity: 0;
       }
     }
+
     .heart-animation {
       position: fixed;
       top: 50%;
@@ -222,6 +428,7 @@
       z-index: 2000;
       animation: growHeart 1s ease-in-out forwards;
     }
+
     @keyframes growMatch {
       0% {
         transform: translate(-50%, -50%) scale(0);
@@ -236,6 +443,7 @@
         opacity: 0;
       }
     }
+
     .match-animation {
       position: fixed;
       top: 50%;
@@ -248,6 +456,7 @@
       z-index: 2000;
       animation: growMatch 1s ease-in-out forwards;
     }
+
     @keyframes growCross {
       0% {
         transform: translate(-50%, -50%) scale(0);
@@ -262,6 +471,7 @@
         opacity: 0;
       }
     }
+
     .cross-animation {
       position: fixed;
       top: 50%;
@@ -273,80 +483,113 @@
       z-index: 2000;
       animation: growCross 1s ease-in-out forwards;
     }
-    .no-profiles-message {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-      text-align: center;
-      padding: 20px;
-      color: #f5f5f5;
-    }
-    .no-profiles-message h2 {
-      margin-bottom: 10px;
-      font-size: 1.8rem;
-      color: #1db954;
-    }
-    .no-profiles-message p {
-      font-size: 1rem;
-      color: #e0e0e0;
+
+    @media (max-width: 960px) {
+      main {
+        padding: 32px 6vw 100px;
+        gap: 36px;
+      }
+
+      .cards-wrapper {
+        order: -1;
+      }
+
+      header {
+        padding: 20px 6vw;
+      }
     }
   </style>
 </head>
 <body>
   <header>
-    <h1><a href="/index1" style="text-decoration: none; color: inherit;">Harmony</a></h1>
+    <a href="/index1" class="logo"><span>♫</span>Harmony</a>
     <div class="header-right">
       <a href="/profile">
-        <img id="profile-pic" class="neon-profile" src="{{ profile_picture_url or 'https://placehold.co/50x50' }}" alt="Profile Picture">
+        <img id="profile-pic" class="profile-thumb" src="{{ profile_picture_url or 'https://placehold.co/50x50' }}" alt="Profile Picture">
       </a>
-      <a href="/logout" id="logout-btn" class="btn neon-logout">Logout</a>
+      <a href="/logout" id="logout-btn" class="btn">Logout</a>
     </div>
   </header>
 
-  <div class="container">
-    <div id="profiles-container">
-      {% if no_profiles %}
-        <div class="no-profiles-message">
-          <h2>No more profiles to explore</h2>
-          <p>You've seen everyone for now. Check back later for new matches!</p>
+  <main>
+    <section class="match-intro">
+      <h1>Discover your next musical connection</h1>
+      <p>Swipe through curated profiles tailored to your taste. Harmony connects you with people who vibe with the same artists, tracks and genres you love.</p>
+      <div class="match-stats">
+        <div class="stat-card">
+          <span>Daily Matches</span>
+          <strong>1.2k</strong>
         </div>
-      {% else %}
-        {% for profile in profiles %}
-          <div class="card" data-id="{{ profile.id }}">
-            <h2>{{ profile.display_name }}</h2>
-            <p><strong>Top Genres:</strong> {{ (profile.genres or [])[:5] | join(', ') }}</p>
-            <div class="top-artists">
-              <h3>Top Artists</h3>
-              {% for artist in (profile.top_artists or [])[:3] %}
-                <div class="artist">
-                  <img src="{{ artist.image or 'https://placehold.co/40x40' }}" alt="{{ artist.name }}">
-                  <p>{{ artist.name }}</p>
+        <div class="stat-card">
+          <span>Shared Playlists</span>
+          <strong>540+</strong>
+        </div>
+        <div class="stat-card">
+          <span>Concert Meetups</span>
+          <strong>320</strong>
+        </div>
+      </div>
+      <div class="match-controls">
+        <a href="/check-matches" class="btn secondary"><i class="fas fa-star"></i> View Matches</a>
+        <a href="/profile" class="btn secondary"><i class="fas fa-user"></i> Update Profile</a>
+      </div>
+    </section>
+
+    <section class="cards-wrapper">
+      <h2>Swipe &amp; Match</h2>
+      <p>Drag cards to the right to like or to the left to pass. Tap the buttons for quick actions.</p>
+      <div class="container">
+        <div id="profiles-container">
+          {% if no_profiles %}
+            <div class="no-profiles">
+              <h2>No more profiles to explore</h2>
+              <p>You've seen everyone for now. Check back later for new matches!</p>
+            </div>
+          {% else %}
+            {% for profile in profiles %}
+              <div class="card" data-id="{{ profile.id }}">
+                <div>
+                  <h2>{{ profile.display_name }}</h2>
+                  {% if profile.genres %}
+                    <div class="tags">
+                      {% for genre in (profile.genres or [])[:5] %}
+                        <span class="tag">{{ genre }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
                 </div>
-              {% endfor %}
-            </div>
-            <div class="top-tracks">
-              <h3>Top Tracks</h3>
-              {% for track in (profile.top_tracks or [])[:3] %}
-                <div class="song">
-                  <img src="{{ track.image or 'https://placehold.co/40x40' }}" alt="{{ track.name }}">
-                  <p>{{ track.name }}</p>
+                <div class="card-section">
+                  <h3>Top Artists</h3>
+                  {% for artist in (profile.top_artists or [])[:3] %}
+                    <div class="artist">
+                      <img src="{{ artist.image or 'https://placehold.co/46x46' }}" alt="{{ artist.name }}">
+                      <p>{{ artist.name }}</p>
+                    </div>
+                  {% endfor %}
                 </div>
-              {% endfor %}
-            </div>
-            <div class="actions">
-              <button class="btn pass"><i class="fas fa-times"></i></button>
-              <button class="btn like"><i class="fas fa-heart"></i></button>
-            </div>
-          </div>
-        {% endfor %}
-      {% endif %}
-    </div>
-  </div>
+                <div class="card-section">
+                  <h3>Top Tracks</h3>
+                  {% for track in (profile.top_tracks or [])[:3] %}
+                    <div class="song">
+                      <img src="{{ track.image or 'https://placehold.co/46x46' }}" alt="{{ track.name }}">
+                      <p>{{ track.name }}</p>
+                    </div>
+                  {% endfor %}
+                </div>
+                <div class="actions">
+                  <button class="pass"><i class="fas fa-times"></i></button>
+                  <button class="like"><i class="fas fa-heart"></i></button>
+                </div>
+              </div>
+            {% endfor %}
+          {% endif %}
+        </div>
+      </div>
+    </section>
+  </main>
 
   <footer>
-    <p>© 2025 Harmony | Built with ❤️ for music lovers.</p>
+    <p>© 2025 Harmony • Built with ❤️ for music lovers.</p>
   </footer>
 
   <script src="{{ url_for('static', filename='js/app.js') }}"></script>


### PR DESCRIPTION
## Summary
- restyle the find profiles template to share the gradient-driven look and typography from the home and dashboard pages
- introduce a hero panel with feature highlights plus refreshed swipe cards, genre tags, and responsive tweaks while preserving existing swipe controls

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dae2d3f9a48327a268ef3d6cc7a308