### PR TITLE
Fix match card layout and button bindings

### DIFF
--- a/static/js/find_match.js
+++ b/static/js/find_match.js
@@ -125,9 +125,9 @@ document.addEventListener("DOMContentLoaded", function() {
 
   // Opsiyonel: Kart üzerindeki like/pass butonlarına click event ekleyelim.
   cards.forEach(card => {
-    const passBtn = card.querySelector(".btn.pass");
-    const likeBtn = card.querySelector(".btn.like");
-  
+    const passBtn = card.querySelector(".pass");
+    const likeBtn = card.querySelector(".like");
+
     if (passBtn) {
       passBtn.addEventListener("click", () => {
         handlePass(card);

--- a/templates/match.html
+++ b/templates/match.html
@@ -198,14 +198,26 @@
 
     .container {
       position: relative;
-      width: clamp(240px, 28vw, 320px);
+      width: 100%;
+      max-width: clamp(280px, 60vw, 360px);
       height: 470px;
       perspective: 1200px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    #profiles-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
     }
 
     .card {
       position: absolute;
       inset: 0;
+      width: 100%;
+      height: 100%;
       background: var(--card);
       border: 1px solid var(--card-border);
       border-radius: 24px;


### PR DESCRIPTION
## Summary
- center the match card stack and ensure it fills the available container space for consistent layout
- hook the like and pass buttons directly so the swipe actions trigger correctly when the controls are clicked

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68dae5cffb048327bd0c635abe572c38