### PR TITLE
Add weighted blend scoring for profile matches

### DIFF
--- a/templates/match.html
+++ b/templates/match.html
@@ -249,6 +249,46 @@
       color: var(--muted);
     }
 
+    .match-score {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-top: 8px;
+    }
+
+    .match-score__badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 14px;
+      border-radius: 999px;
+      background: rgba(29, 185, 84, 0.2);
+      color: var(--text);
+      font-weight: 600;
+      font-size: 0.8rem;
+      border: 1px solid rgba(29, 185, 84, 0.35);
+      letter-spacing: 0.02em;
+    }
+
+    .match-score__track {
+      position: relative;
+      flex: 1;
+      height: 8px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.1);
+      overflow: hidden;
+    }
+
+    .match-score__fill {
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      border-radius: inherit;
+      background: var(--primary);
+      box-shadow: 0 6px 14px rgba(29, 185, 84, 0.4);
+    }
+
     .card-section {
       background: rgba(255, 255, 255, 0.03);
       border-radius: 18px;
@@ -488,6 +528,14 @@
               <div class="card" data-id="{{ profile.id }}">
                 <div>
                   <h2>{{ profile.display_name }}</h2>
+                  {% if profile.match_score is not none %}
+                    <div class="match-score">
+                      <span class="match-score__badge">Match {{ profile.match_score }}%</span>
+                      <div class="match-score__track">
+                        <span class="match-score__fill" style="width: {{ profile.match_score }}%"></span>
+                      </div>
+                    </div>
+                  {% endif %}
                   {% if profile.genres %}
                     <div class="tags">
                       {% for genre in (profile.genres or [])[:5] %}

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,69 @@
+import pytest
+
+from types import SimpleNamespace
+
+from harmony.routes.main import calculate_blend_score
+
+
+def make_user(artists=None, tracks=None, genres=None):
+    return SimpleNamespace(top_artists=artists, top_tracks=tracks, genres=genres)
+
+
+def test_calculate_blend_score_identical_preferences():
+    artists = [
+        {"name": "Artist One"},
+        {"name": "Artist Two"},
+    ]
+    tracks = [
+        {"name": "Track A"},
+        {"name": "Track B"},
+    ]
+    genres = ["Pop", "Indie"]
+
+    user = make_user(artists=artists, tracks=tracks, genres=genres)
+    candidate = make_user(artists=artists, tracks=tracks, genres=genres)
+
+    score = calculate_blend_score(user, candidate)
+    assert score == pytest.approx(1.0)
+
+
+def test_calculate_blend_score_partial_overlap():
+    current_user = make_user(
+        artists=[
+            {"name": "Artist One"},
+            {"name": "Artist Two"},
+            {"name": "Artist Three"},
+        ],
+        tracks=[
+            {"name": "Track A"},
+            {"name": "Track B"},
+            {"name": "Track C"},
+        ],
+        genres=[["Pop", "Rock"]],
+    )
+
+    candidate = make_user(
+        artists=[
+            {"name": "Artist One"},
+            {"name": "Artist Four"},
+            {"name": "Artist Five"},
+        ],
+        tracks=[
+            {"name": "Track A"},
+            {"name": "Track D"},
+            {"name": "Track E"},
+        ],
+        genres=[["Rock", "Jazz"]],
+    )
+
+    score = calculate_blend_score(current_user, candidate)
+
+    expected = 0.4 * (1 / 5) + 0.4 * (1 / 5) + 0.2 * (1 / 3)
+    assert score == pytest.approx(expected)
+
+
+def test_calculate_blend_score_no_data_returns_zero():
+    user = make_user()
+    candidate = make_user()
+
+    assert calculate_blend_score(user, candidate) == 0.0


### PR DESCRIPTION
## Summary
- add a reusable helper that derives weighted blend scores from shared artists, tracks, and genres
- rank discoverable profiles by match percentage and expose the score to the match view
- surface the score in the match card UI and cover the helper logic with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dafe17e44c83279a7e1b41b011636a